### PR TITLE
chore: bump claude model to current pinned ids

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,7 +35,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          model: "claude-opus-4-5-20251101"
+          model: "claude-opus-4-7"
 
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -41,7 +41,7 @@ jobs:
             actions: read
           
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          model: "claude-opus-4-5-20251101"
+          model: "claude-opus-4-7"
           
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"


### PR DESCRIPTION
Bumps any dated or older Opus/Sonnet model references to canonical ids (`claude-opus-4-7`, `claude-sonnet-4-6`). Follow-up to the main 4.6 -> 4.7 batch run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)