### PR TITLE
chore: bump claude model to claude-opus-4-8

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,7 +35,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          model: "claude-opus-4-7"
+          model: "claude-opus-4-8"
 
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -41,7 +41,7 @@ jobs:
             actions: read
           
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          model: "claude-opus-4-7"
+          model: "claude-opus-4-8"
           
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"


### PR DESCRIPTION
Automated bump of the `model:` line in `.github/workflows/claude.yml` and `claude-code-review.yml` to `claude-opus-4-8`.

This was generated by the `update-claude-version` skill after the new Claude model rolled out. Verified end-to-end on cross-eco-internal-docs (issue #186, PR #187) before this batch run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)