### PR TITLE
security: harden MCP policy and publishing

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -23,14 +23,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
           ref: ${{ github.event_name == 'issue_comment' && format('refs/pull/{0}/head', github.event.issue.number) || github.ref }}
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@de8e0b9c42c6cb58e904c857f164aa072244c1ac # beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,13 +26,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@de8e0b9c42c6cb58e904c857f164aa072244c1ac # beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,36 @@
+name: Publish npm package
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: npm
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 20
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build package
+        run: npm run build
+
+      - name: Publish with provenance
+        run: npm publish --provenance --access public

--- a/README.md
+++ b/README.md
@@ -22,10 +22,13 @@ Resolution order:
 
 First-run flow:
 
-1. Call MCP tool `deva_agent_register` with `name` (+ optional `description`)
-2. Server calls `POST /agents/register`
-3. Returned `api_key` is persisted
-4. All authenticated requests use `Authorization: Bearer deva_xxx`
+1. Prefer setting `DEVA_API_KEY` from an agent registered outside the MCP server.
+2. To register through MCP, temporarily enable `deva_agent_register` in local `tool_policy.enabled_tools`.
+3. Call MCP tool `deva_agent_register` with `name` (+ optional `description`)
+4. Server calls `POST /agents/register`
+5. Returned `api_key` is persisted
+6. Remove `deva_agent_register` from `tool_policy.enabled_tools` after registration unless you still need it.
+7. All authenticated requests use `Authorization: Bearer deva_xxx`
 
 ## Pricing (Current)
 
@@ -36,9 +39,9 @@ First-run flow:
 | Image generation | 80₭ ($0.08) standard, 160₭ ($0.16) HD |
 | Embeddings | 1₭ ($0.001) per 1K tokens |
 | Vision | 20₭ ($0.02) per image |
-| Web search | 5₭ ($0.005) per search |
-| X search | 15₭ ($0.015) per search |
-| X user tweets | 15₭ ($0.015) per request |
+| Web search | 10₭ ($0.01) per search |
+| X search | 10₭ ($0.01) per search |
+| X user tweets | 10₭ ($0.01) per request |
 | KV store writes | 1₭ ($0.001) per write (reads free) |
 | File uploads | 1₭ ($0.001) per upload (downloads free) |
 | Transcription | 5₭ ($0.005) per 24s |
@@ -47,6 +50,43 @@ First-run flow:
 | Gas faucet | 350₭ ($0.35) |
 
 Use `deva_cost_estimate` before execution and `deva_resources_catalog` for live catalog/pricing from the API.
+
+## Local Tool Policy
+
+The server starts in a least-privilege mode. Free read tools are listed by default. Paid tools and tools that change account, storage, social, webhook, cron, marketplace, server, or messaging state are hidden from `list_tools` and rejected if called directly until they are explicitly enabled in `~/.deva-mcp/config.json`.
+
+Paid tools also require spend caps. Caps are tracked per MCP server process and reset when the process restarts. Returned `karma_cost` values count against the caps; x402 payment challenges are checked against remaining caps before the challenge is returned to the client.
+
+Example:
+
+```json
+{
+  "profile": "default",
+  "api_base": "https://api.deva.me",
+  "agents": {
+    "default": {
+      "name": "my_agent.genie",
+      "api_key": "deva_xxx"
+    }
+  },
+  "defaults": {
+    "timeout_ms": 30000
+  },
+  "tool_policy": {
+    "enabled_tools": ["deva_ai_tts", "deva_storage_kv_set"],
+    "spend_caps": {
+      "session_karma": 100,
+      "default_tool_karma": 25,
+      "per_tool_karma": {
+        "deva_ai_tts": 50,
+        "deva_storage_kv_set": 10
+      }
+    }
+  }
+}
+```
+
+For paid tools, set both `spend_caps.session_karma` and either `spend_caps.default_tool_karma` or a `spend_caps.per_tool_karma` entry for the enabled tool.
 
 ## x402 USDC Payment Flow
 
@@ -72,7 +112,7 @@ Example tool error payload:
 }
 ```
 
-Clients/agents can use this challenge to pay with USDC, then retry the same tool call.
+Clients/agents can use this challenge to pay with USDC, then retry the same tool call. If the challenge amount exceeds the configured local caps, the server returns a local policy error instead of the challenge.
 
 ## MCP Configuration
 
@@ -264,6 +304,14 @@ Config shape:
   },
   "defaults": {
     "timeout_ms": 30000
+  },
+  "tool_policy": {
+    "enabled_tools": [],
+    "spend_caps": {
+      "session_karma": 0,
+      "default_tool_karma": 0,
+      "per_tool_karma": {}
+    }
   }
 }
 ```
@@ -282,3 +330,5 @@ Scripts:
 - `npm run dev`
 - `npm run start`
 - `npm run test`
+
+Release publishing is documented in [docs/release-runbook.md](docs/release-runbook.md).

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Use `deva_cost_estimate` before execution and `deva_resources_catalog` for live 
 
 The server starts in a least-privilege mode. Free read tools are listed by default. Paid tools and tools that change account, storage, social, webhook, cron, marketplace, server, or messaging state are hidden from `list_tools` and rejected if called directly until they are explicitly enabled in `~/.deva-mcp/config.json`.
 
-Paid tools also require spend caps. Caps are tracked per MCP server process and reset when the process restarts. Returned `karma_cost` values count against the caps; x402 payment challenges are checked against remaining caps before the challenge is returned to the client.
+Paid tools also require spend caps. Caps are tracked per MCP server process and reset when the process restarts. Paid calls reserve local budget before the upstream request, and returned `karma_cost` values settle against that reservation. If a successful paid response omits a parseable cost or returns a cost above the remaining cap, the MCP call fails with a local policy error. x402 payment challenges are checked against remaining caps before the challenge is returned to the client.
 
 Example:
 

--- a/TASK.md
+++ b/TASK.md
@@ -1,12 +1,12 @@
-# Task: Build @deva/mcp-server
+# Task: Build @deva-me/mcp-server
 
-You are building a Deva MCP Server — an npm package (`@deva/mcp-server`) that exposes Deva's Agent Resources REST API as MCP tools for Claude Code, Cursor, OpenClaw, and any MCP-compatible client.
+You are building a Deva MCP Server — an npm package (`@deva-me/mcp-server`) that exposes Deva's Agent Resources REST API as MCP tools for Claude Code, Cursor, OpenClaw, and any MCP-compatible client.
 
 ## Architecture
 
 - **Runtime:** Node.js 20+ / TypeScript (ESM)
 - **MCP transport:** stdio (use `@modelcontextprotocol/sdk`)
-- **Package name:** `@deva/mcp-server`
+- **Package name:** `@deva-me/mcp-server`
 - **Binary name:** `deva-mcp-server` (for npx execution)
 
 ## Structure
@@ -158,7 +158,7 @@ All tools use `deva_<domain>_<action>` naming.
   "mcpServers": {
     "deva": {
       "command": "npx",
-      "args": ["-y", "@deva/mcp-server"],
+      "args": ["-y", "@deva-me/mcp-server"],
       "env": { "DEVA_API_KEY": "deva_xxx" }
     }
   }
@@ -171,7 +171,7 @@ All tools use `deva_<domain>_<action>` naming.
   "mcpServers": {
     "deva": {
       "command": "npx",
-      "args": ["-y", "@deva/mcp-server"]
+      "args": ["-y", "@deva-me/mcp-server"]
     }
   }
 }
@@ -181,7 +181,7 @@ All tools use `deva_<domain>_<action>` naming.
 ```toml
 [mcp_servers.deva]
 command = "npx"
-args = ["-y", "@deva/mcp-server"]
+args = ["-y", "@deva-me/mcp-server"]
 
 [mcp_servers.deva.env]
 DEVA_API_KEY = "deva_xxx"
@@ -204,10 +204,10 @@ DEVA_API_KEY = "deva_xxx"
 
 ## Deliverables
 
-1. Working MCP server that can be run via `npx @deva/mcp-server`
+1. Working MCP server that can be run via `npx @deva-me/mcp-server`
 2. All tools listed above implemented and typed
 3. README with setup instructions and integration examples
 4. package.json with proper bin field, dependencies, build script
 5. Initial commit with everything working
 
-When completely finished, run: git add -A && git commit -m "feat: initial @deva/mcp-server with 35+ MCP tools" && git push -u origin master
+When completely finished, run: git add -A && git commit -m "feat: initial @deva-me/mcp-server with 35+ MCP tools" && git push -u origin master

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -1,0 +1,24 @@
+# Release Runbook
+
+## Package
+
+The canonical npm package name is `@deva-me/mcp-server`.
+
+## Trusted Publishing Setup
+
+The repository includes `.github/workflows/publish.yml`, which publishes tagged releases with GitHub Actions OIDC and npm provenance. Before the first release through that workflow, an npm package owner must configure a trusted publisher for `@deva-me/mcp-server` in npm:
+
+- Repository: `Deva-me-AI/mcp-server`
+- Workflow: `publish.yml`
+- Environment: `npm`
+- Package: `@deva-me/mcp-server`
+
+No `NPM_TOKEN` is required for this path.
+
+## Release Steps
+
+1. Update `package.json` and `package-lock.json` to the intended version.
+2. Confirm the package contents with `npm pack --dry-run`.
+3. Push a protected release tag such as `v0.1.3`.
+4. Confirm the GitHub Actions publish workflow completes.
+5. Verify the npm release metadata and provenance for the published version.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@deva/mcp-server",
+  "name": "@deva-me/mcp-server",
   "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@deva/mcp-server",
+      "name": "@deva-me/mcp-server",
       "version": "0.1.2",
       "license": "MIT",
       "dependencies": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,8 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { buildDefaultToolPolicyConfig, normalizeToolPolicyConfig } from "./tool-policy.js";
+import type { ToolPolicyConfig } from "./tool-policy.js";
 
 export type LogLevel = "error" | "warn" | "info" | "debug";
 
@@ -16,6 +18,7 @@ export interface DevaMcpConfigFile {
   defaults: {
     timeout_ms: number;
   };
+  tool_policy: ToolPolicyConfig;
 }
 
 export interface RuntimeConfig {
@@ -26,6 +29,7 @@ export interface RuntimeConfig {
   logLevel: LogLevel;
   configPath: string;
   configFile: DevaMcpConfigFile;
+  toolPolicy: ToolPolicyConfig;
 }
 
 const DEFAULT_API_BASE = "https://api.deva.me";
@@ -58,7 +62,8 @@ function buildDefaultFile(): DevaMcpConfigFile {
     },
     defaults: {
       timeout_ms: DEFAULT_TIMEOUT_MS
-    }
+    },
+    tool_policy: buildDefaultToolPolicyConfig()
   };
 }
 
@@ -76,7 +81,8 @@ export async function loadConfig(): Promise<RuntimeConfig> {
       agents: parsed.agents ?? { [DEFAULT_PROFILE]: {} },
       defaults: {
         timeout_ms: parsed.defaults?.timeout_ms ?? DEFAULT_TIMEOUT_MS
-      }
+      },
+      tool_policy: normalizeToolPolicyConfig(parsed.tool_policy)
     };
   } catch {
     await saveConfigFile(configPath, fileConfig);
@@ -101,7 +107,8 @@ export async function loadConfig(): Promise<RuntimeConfig> {
     timeoutMs,
     logLevel,
     configPath,
-    configFile: fileConfig
+    configFile: fileConfig,
+    toolPolicy: fileConfig.tool_policy
   };
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,7 @@ import { withKarmaCost } from "./billing.js";
 import { RuntimeConfig, redactApiKey } from "./config.js";
 import { DevaClient } from "./deva-client.js";
 import { formatErrorForTool } from "./errors.js";
+import { ToolPolicyEnforcer, assertKnownToolPolicies } from "./tool-policy.js";
 import { createAgentTools } from "./tools/agent.js";
 import { createAiTools } from "./tools/ai.js";
 import { createBalanceTools } from "./tools/balance.js";
@@ -34,6 +35,7 @@ export class DevaMcpServer {
   private readonly client: DevaClient;
   private readonly auth: AuthManager;
   private readonly tools: ToolDefinition[];
+  private readonly toolPolicy: ToolPolicyEnforcer;
 
   constructor(private readonly config: RuntimeConfig) {
     this.client = new DevaClient(config, () => this.config.apiKey);
@@ -55,11 +57,13 @@ export class DevaMcpServer {
       ...createMarketplaceTools(),
       ...createServerTools()
     ];
+    assertKnownToolPolicies(this.tools);
+    this.toolPolicy = new ToolPolicyEnforcer(config.toolPolicy);
 
     this.mcpServer = new Server(
       {
-        name: "@deva/mcp-server",
-        version: "0.1.0"
+        name: "@deva-me/mcp-server",
+        version: "0.1.2"
       },
       {
         capabilities: {
@@ -80,11 +84,13 @@ export class DevaMcpServer {
   private registerHandlers(): void {
     this.mcpServer.setRequestHandler(ListToolsRequestSchema, async () => {
       return {
-        tools: this.tools.map((tool) => ({
-          name: tool.name,
-          description: tool.description,
-          inputSchema: tool.inputSchema
-        }))
+        tools: this.tools
+          .filter((tool) => this.toolPolicy.canList(tool.name))
+          .map((tool) => ({
+            name: tool.name,
+            description: tool.description,
+            inputSchema: tool.inputSchema
+          }))
       };
     });
 
@@ -100,6 +106,8 @@ export class DevaMcpServer {
       }
 
       try {
+        this.toolPolicy.assertCanExecute(toolName);
+
         const args = (request.params.arguments ?? {}) as Record<string, unknown>;
         const context: ToolContext = {
           client: this.client,
@@ -107,6 +115,7 @@ export class DevaMcpServer {
         };
 
         const payload = await tool.execute(args, context);
+        this.toolPolicy.recordSpend(toolName, payload);
         const decorated = payload && typeof payload === "object" ? withKarmaCost(payload as Record<string, unknown>) : payload;
 
         return {
@@ -118,7 +127,13 @@ export class DevaMcpServer {
           ]
         };
       } catch (error) {
-        const message = formatErrorForTool(error);
+        let message: string;
+        try {
+          this.toolPolicy.assertPaymentChallengeWithinCaps(toolName, error);
+          message = formatErrorForTool(error);
+        } catch (policyError) {
+          message = formatErrorForTool(policyError);
+        }
         return {
           isError: true,
           content: [

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,7 +6,7 @@ import { withKarmaCost } from "./billing.js";
 import { RuntimeConfig, redactApiKey } from "./config.js";
 import { DevaClient } from "./deva-client.js";
 import { formatErrorForTool } from "./errors.js";
-import { ToolPolicyEnforcer, assertKnownToolPolicies } from "./tool-policy.js";
+import { ToolPolicyEnforcer, ToolSpendReservation, assertKnownToolPolicies } from "./tool-policy.js";
 import { createAgentTools } from "./tools/agent.js";
 import { createAiTools } from "./tools/ai.js";
 import { createBalanceTools } from "./tools/balance.js";
@@ -105,9 +105,10 @@ export class DevaMcpServer {
         };
       }
 
-      try {
-        this.toolPolicy.assertCanExecute(toolName);
+      let spendReservation: ToolSpendReservation | undefined;
 
+      try {
+        spendReservation = this.toolPolicy.reserveSpend(toolName);
         const args = (request.params.arguments ?? {}) as Record<string, unknown>;
         const context: ToolContext = {
           client: this.client,
@@ -115,7 +116,8 @@ export class DevaMcpServer {
         };
 
         const payload = await tool.execute(args, context);
-        this.toolPolicy.recordSpend(toolName, payload);
+        this.toolPolicy.settleSpend(spendReservation, payload);
+        spendReservation = undefined;
         const decorated = payload && typeof payload === "object" ? withKarmaCost(payload as Record<string, unknown>) : payload;
 
         return {
@@ -127,6 +129,7 @@ export class DevaMcpServer {
           ]
         };
       } catch (error) {
+        this.toolPolicy.releaseSpend(spendReservation);
         let message: string;
         try {
           this.toolPolicy.assertPaymentChallengeWithinCaps(toolName, error);

--- a/src/tool-policy.ts
+++ b/src/tool-policy.ts
@@ -21,6 +21,12 @@ interface RemainingBudget {
   tool: number;
 }
 
+export interface ToolSpendReservation {
+  toolName: string;
+  reservedKarma: number;
+  state: "pending" | "released" | "settled";
+}
+
 const KARMA_PER_USDC = 1000;
 
 const paid = (): ToolSecurityMetadata => ({ paid: true });
@@ -244,7 +250,9 @@ function challengeAmountToKarma(challenge: PaymentChallenge | undefined): number
 export class ToolPolicyEnforcer {
   private readonly enabledTools: Set<string>;
   private sessionKarmaSpent = 0;
+  private sessionKarmaPending = 0;
   private readonly toolKarmaSpent = new Map<string, number>();
+  private readonly toolKarmaPending = new Map<string, number>();
 
   constructor(private readonly config: ToolPolicyConfig) {
     this.enabledTools = new Set(config.enabled_tools);
@@ -270,6 +278,66 @@ export class ToolPolicyEnforcer {
     }
   }
 
+  reserveSpend(toolName: string): ToolSpendReservation | undefined {
+    this.assertCanExecute(toolName);
+
+    if (!getToolSecurityMetadata(toolName).paid) {
+      return undefined;
+    }
+
+    const remaining = this.getRemainingBudget(toolName);
+    const reservedKarma = Math.min(remaining.session, remaining.tool);
+    this.assertBudgetAvailable(toolName, reservedKarma);
+
+    const reservation: ToolSpendReservation = {
+      toolName,
+      reservedKarma,
+      state: "pending"
+    };
+
+    this.sessionKarmaPending += reservedKarma;
+    this.toolKarmaPending.set(toolName, this.getToolKarmaPending(toolName) + reservedKarma);
+
+    return reservation;
+  }
+
+  settleSpend(reservation: ToolSpendReservation | undefined, payload: unknown): number | undefined {
+    if (!reservation) {
+      return undefined;
+    }
+
+    const toolName = reservation.toolName;
+    const cost = extractKarmaCost(payload);
+    if (cost === undefined) {
+      this.settleReservation(reservation, reservation.reservedKarma);
+      throw this.denied(
+        `Paid tool '${toolName}' completed without a parseable karma cost; the reserved ${reservation.reservedKarma} karma was counted against local spend caps because the actual cost cannot be verified.`
+      );
+    }
+
+    const remaining = this.getRemainingBudgetAfterReleasing(reservation);
+    const capError = this.getCapExceededError(toolName, cost, remaining);
+    this.settleReservation(reservation, cost);
+    if (capError) {
+      throw capError;
+    }
+
+    return cost;
+  }
+
+  releaseSpend(reservation: ToolSpendReservation | undefined): void {
+    if (!reservation || reservation.state !== "pending") {
+      return;
+    }
+
+    reservation.state = "released";
+    this.sessionKarmaPending = Math.max(0, this.sessionKarmaPending - reservation.reservedKarma);
+    this.toolKarmaPending.set(
+      reservation.toolName,
+      Math.max(0, this.getToolKarmaPending(reservation.toolName) - reservation.reservedKarma)
+    );
+  }
+
   recordSpend(toolName: string, payload: unknown): number | undefined {
     if (!getToolSecurityMetadata(toolName).paid) {
       return undefined;
@@ -277,11 +345,17 @@ export class ToolPolicyEnforcer {
 
     const cost = extractKarmaCost(payload);
     if (cost === undefined) {
-      return undefined;
+      throw this.denied(`Paid tool '${toolName}' completed without a parseable karma cost, so local spend caps cannot be enforced.`);
     }
 
+    this.assertPaidBudgetConfigured(toolName);
+    const capError = this.getCapExceededError(toolName, cost, this.getRemainingBudget(toolName));
     this.sessionKarmaSpent += cost;
     this.toolKarmaSpent.set(toolName, this.getToolKarmaSpent(toolName) + cost);
+    if (capError) {
+      throw capError;
+    }
+
     return cost;
   }
 
@@ -308,8 +382,16 @@ export class ToolPolicyEnforcer {
     return this.sessionKarmaSpent;
   }
 
+  getSessionKarmaPending(): number {
+    return this.sessionKarmaPending;
+  }
+
   getToolKarmaSpent(toolName: string): number {
     return this.toolKarmaSpent.get(toolName) ?? 0;
+  }
+
+  getToolKarmaPending(toolName: string): number {
+    return this.toolKarmaPending.get(toolName) ?? 0;
   }
 
   private assertPaidBudgetConfigured(toolName: string): void {
@@ -336,10 +418,55 @@ export class ToolPolicyEnforcer {
     }
   }
 
+  private getCapExceededError(toolName: string, cost: number, remaining: RemainingBudget): DevaError | undefined {
+    if (cost > remaining.session) {
+      return this.denied(
+        `Paid tool '${toolName}' returned a karma cost of ${cost}, which would exceed the remaining per-session karma spend cap.`
+      );
+    }
+
+    if (cost > remaining.tool) {
+      return this.denied(
+        `Paid tool '${toolName}' returned a karma cost of ${cost}, which would exceed its remaining per-tool karma spend cap.`
+      );
+    }
+
+    return undefined;
+  }
+
+  private settleReservation(reservation: ToolSpendReservation, cost: number): void {
+    if (reservation.state !== "pending") {
+      return;
+    }
+
+    reservation.state = "settled";
+    this.sessionKarmaPending = Math.max(0, this.sessionKarmaPending - reservation.reservedKarma);
+    this.toolKarmaPending.set(
+      reservation.toolName,
+      Math.max(0, this.getToolKarmaPending(reservation.toolName) - reservation.reservedKarma)
+    );
+    this.sessionKarmaSpent += cost;
+    this.toolKarmaSpent.set(reservation.toolName, this.getToolKarmaSpent(reservation.toolName) + cost);
+  }
+
   private getRemainingBudget(toolName: string): RemainingBudget {
     return {
-      session: this.config.spend_caps.session_karma - this.sessionKarmaSpent,
-      tool: this.getToolCap(toolName) - this.getToolKarmaSpent(toolName)
+      session: this.config.spend_caps.session_karma - this.sessionKarmaSpent - this.sessionKarmaPending,
+      tool: this.getToolCap(toolName) - this.getToolKarmaSpent(toolName) - this.getToolKarmaPending(toolName)
+    };
+  }
+
+  private getRemainingBudgetAfterReleasing(reservation: ToolSpendReservation): RemainingBudget {
+    const pendingSessionRelease = reservation.state === "pending" ? reservation.reservedKarma : 0;
+    const pendingToolRelease = reservation.state === "pending" ? reservation.reservedKarma : 0;
+
+    return {
+      session:
+        this.config.spend_caps.session_karma - this.sessionKarmaSpent - Math.max(0, this.sessionKarmaPending - pendingSessionRelease),
+      tool:
+        this.getToolCap(reservation.toolName) -
+        this.getToolKarmaSpent(reservation.toolName) -
+        Math.max(0, this.getToolKarmaPending(reservation.toolName) - pendingToolRelease)
     };
   }
 

--- a/src/tool-policy.ts
+++ b/src/tool-policy.ts
@@ -1,0 +1,356 @@
+import { DevaError } from "./errors.js";
+import type { PaymentChallenge } from "./errors.js";
+import type { ToolDefinition } from "./tools/types.js";
+
+export interface ToolPolicyConfig {
+  enabled_tools: string[];
+  spend_caps: {
+    session_karma: number;
+    default_tool_karma: number;
+    per_tool_karma: Record<string, number>;
+  };
+}
+
+export interface ToolSecurityMetadata {
+  paid?: boolean;
+  destructive?: boolean;
+}
+
+interface RemainingBudget {
+  session: number;
+  tool: number;
+}
+
+const KARMA_PER_USDC = 1000;
+
+const paid = (): ToolSecurityMetadata => ({ paid: true });
+const destructive = (): ToolSecurityMetadata => ({ destructive: true });
+const paidDestructive = (): ToolSecurityMetadata => ({ paid: true, destructive: true });
+const safe = (): ToolSecurityMetadata => ({});
+
+const TOOL_SECURITY: Record<string, ToolSecurityMetadata> = {
+  deva_agent_register: destructive(),
+  deva_agent_status: safe(),
+  deva_agents_discover: safe(),
+  deva_agent_me_get: safe(),
+  deva_agent_me_update: destructive(),
+  deva_agent_profile_get: safe(),
+  deva_agent_verify: destructive(),
+
+  deva_social_post_create: paidDestructive(),
+  deva_social_feed_get: safe(),
+  deva_social_post_get: safe(),
+  deva_social_post_replies_get: safe(),
+  deva_social_post_react: paidDestructive(),
+  deva_social_agents_search: safe(),
+  deva_social_follow: destructive(),
+  deva_social_unfollow: destructive(),
+  deva_social_followers_get: safe(),
+  deva_social_following_get: safe(),
+  deva_social_x_search: paid(),
+  deva_social_prompt: paidDestructive(),
+  deva_social_x_user_tweets: paid(),
+
+  deva_ai_tts: paid(),
+  deva_ai_image_generate: paid(),
+  deva_ai_embeddings: paid(),
+  deva_ai_vision_analyze: paid(),
+  deva_ai_web_search: paid(),
+  deva_ai_llm_completion: paid(),
+  deva_ai_transcription: paid(),
+
+  deva_storage_kv_set: paidDestructive(),
+  deva_storage_kv_get: safe(),
+  deva_storage_kv_delete: paidDestructive(),
+  deva_storage_kv_list: safe(),
+  deva_storage_file_upload: paidDestructive(),
+  deva_storage_file_download: safe(),
+  deva_storage_file_delete: paidDestructive(),
+  deva_storage_file_list: safe(),
+
+  deva_balance_get: safe(),
+  deva_cost_estimate: safe(),
+  deva_resources_catalog: safe(),
+
+  deva_messaging_send: paidDestructive(),
+  deva_messaging_inbox: safe(),
+  deva_messaging_outbox: safe(),
+  deva_messaging_reply: paidDestructive(),
+  deva_messaging_mark_read: destructive(),
+  deva_messaging_delete: paidDestructive(),
+  deva_messaging_thread_get: safe(),
+
+  deva_comms_email_send: paidDestructive(),
+  deva_gas_faucet: paidDestructive(),
+
+  deva_feature_request_submit: paidDestructive(),
+  deva_feature_request_vote: paidDestructive(),
+
+  deva_webhook_register: paidDestructive(),
+  deva_webhook_list: safe(),
+  deva_webhook_update: paidDestructive(),
+  deva_webhook_delete: paidDestructive(),
+
+  deva_capability_register: paidDestructive(),
+  deva_capability_search: safe(),
+  deva_capability_list: safe(),
+  deva_capability_update: paidDestructive(),
+  deva_capability_delete: paidDestructive(),
+
+  deva_cron_create: paidDestructive(),
+  deva_cron_list: safe(),
+  deva_cron_update: paidDestructive(),
+  deva_cron_delete: paidDestructive(),
+  deva_cron_runs: safe(),
+
+  deva_marketplace_browse: safe(),
+  deva_marketplace_listing_create: paidDestructive(),
+  deva_marketplace_listing_get: safe(),
+  deva_marketplace_listing_update: paidDestructive(),
+  deva_marketplace_listing_delete: paidDestructive(),
+  deva_marketplace_hire: paidDestructive(),
+  deva_marketplace_hires_list: safe(),
+  deva_marketplace_hire_accept: paidDestructive(),
+  deva_marketplace_hire_decline: paidDestructive(),
+  deva_marketplace_hire_deliver: paidDestructive(),
+  deva_marketplace_hire_accept_delivery: paidDestructive(),
+  deva_marketplace_hire_cancel: paidDestructive(),
+
+  deva_server_provision: paidDestructive(),
+  deva_server_list: safe(),
+  deva_server_delete: paidDestructive()
+};
+
+export function buildDefaultToolPolicyConfig(): ToolPolicyConfig {
+  return {
+    enabled_tools: [],
+    spend_caps: {
+      session_karma: 0,
+      default_tool_karma: 0,
+      per_tool_karma: {}
+    }
+  };
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" ? (value as Record<string, unknown>) : undefined;
+}
+
+function parseNonNegativeNumber(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    return 0;
+  }
+  return value;
+}
+
+function parseToolList(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return [...new Set(value.filter((entry): entry is string => typeof entry === "string" && entry.length > 0))];
+}
+
+function parsePerToolCaps(value: unknown): Record<string, number> {
+  const raw = asRecord(value);
+  if (!raw) {
+    return {};
+  }
+
+  const caps: Record<string, number> = {};
+  for (const [toolName, cap] of Object.entries(raw)) {
+    const parsed = parseNonNegativeNumber(cap);
+    if (parsed > 0) {
+      caps[toolName] = parsed;
+    }
+  }
+  return caps;
+}
+
+export function normalizeToolPolicyConfig(value: unknown): ToolPolicyConfig {
+  const raw = asRecord(value);
+  const spendCaps = asRecord(raw?.spend_caps);
+
+  return {
+    enabled_tools: parseToolList(raw?.enabled_tools),
+    spend_caps: {
+      session_karma: parseNonNegativeNumber(spendCaps?.session_karma),
+      default_tool_karma: parseNonNegativeNumber(spendCaps?.default_tool_karma),
+      per_tool_karma: parsePerToolCaps(spendCaps?.per_tool_karma)
+    }
+  };
+}
+
+export function assertKnownToolPolicies(tools: ToolDefinition[]): void {
+  const missing = tools.map((tool) => tool.name).filter((name) => TOOL_SECURITY[name] === undefined);
+  if (missing.length > 0) {
+    throw new Error(`Missing local security policy metadata for tools: ${missing.join(", ")}`);
+  }
+}
+
+export function getToolSecurityMetadata(toolName: string): ToolSecurityMetadata {
+  return TOOL_SECURITY[toolName] ?? { paid: true, destructive: true };
+}
+
+function isRestricted(metadata: ToolSecurityMetadata): boolean {
+  return metadata.paid === true || metadata.destructive === true;
+}
+
+function asPositiveFiniteNumber(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return undefined;
+  }
+  return value;
+}
+
+function parseKarmaCost(value: unknown): number | undefined {
+  if (typeof value === "number") {
+    return asPositiveFiniteNumber(value);
+  }
+
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number(value);
+    return asPositiveFiniteNumber(parsed);
+  }
+
+  return undefined;
+}
+
+export function extractKarmaCost(payload: unknown): number | undefined {
+  const record = asRecord(payload);
+  if (!record) {
+    return undefined;
+  }
+
+  for (const key of ["karma_cost", "karmaCost", "cost_karma"]) {
+    const cost = parseKarmaCost(record[key]);
+    if (cost !== undefined) {
+      return cost;
+    }
+  }
+
+  return extractKarmaCost(record.data);
+}
+
+function challengeAmountToKarma(challenge: PaymentChallenge | undefined): number | undefined {
+  const amount = parseKarmaCost(challenge?.amount);
+  if (amount === undefined) {
+    return undefined;
+  }
+
+  return amount * KARMA_PER_USDC;
+}
+
+export class ToolPolicyEnforcer {
+  private readonly enabledTools: Set<string>;
+  private sessionKarmaSpent = 0;
+  private readonly toolKarmaSpent = new Map<string, number>();
+
+  constructor(private readonly config: ToolPolicyConfig) {
+    this.enabledTools = new Set(config.enabled_tools);
+  }
+
+  canList(toolName: string): boolean {
+    const metadata = getToolSecurityMetadata(toolName);
+    return !isRestricted(metadata) || this.enabledTools.has(toolName);
+  }
+
+  assertCanExecute(toolName: string): void {
+    const metadata = getToolSecurityMetadata(toolName);
+
+    if (isRestricted(metadata) && !this.enabledTools.has(toolName)) {
+      throw this.denied(
+        `Tool '${toolName}' is disabled by local policy. Add it to tool_policy.enabled_tools to enable paid or state-changing tools.`
+      );
+    }
+
+    if (metadata.paid) {
+      this.assertPaidBudgetConfigured(toolName);
+      this.assertBudgetAvailable(toolName, 0);
+    }
+  }
+
+  recordSpend(toolName: string, payload: unknown): number | undefined {
+    if (!getToolSecurityMetadata(toolName).paid) {
+      return undefined;
+    }
+
+    const cost = extractKarmaCost(payload);
+    if (cost === undefined) {
+      return undefined;
+    }
+
+    this.sessionKarmaSpent += cost;
+    this.toolKarmaSpent.set(toolName, this.getToolKarmaSpent(toolName) + cost);
+    return cost;
+  }
+
+  assertPaymentChallengeWithinCaps(toolName: string, error: unknown): void {
+    if (!(error instanceof DevaError)) {
+      return;
+    }
+
+    if (!getToolSecurityMetadata(toolName).paid || (error.status !== 402 && error.code !== "PAYMENT_REQUIRED")) {
+      return;
+    }
+
+    this.assertPaidBudgetConfigured(toolName);
+
+    const challengeKarma = challengeAmountToKarma(error.paymentChallenge);
+    if (challengeKarma === undefined) {
+      throw this.denied(`Payment challenge for '${toolName}' did not include a parseable amount, so local spend caps cannot be enforced.`);
+    }
+
+    this.assertBudgetAvailable(toolName, challengeKarma);
+  }
+
+  getSessionKarmaSpent(): number {
+    return this.sessionKarmaSpent;
+  }
+
+  getToolKarmaSpent(toolName: string): number {
+    return this.toolKarmaSpent.get(toolName) ?? 0;
+  }
+
+  private assertPaidBudgetConfigured(toolName: string): void {
+    if (this.config.spend_caps.session_karma <= 0) {
+      throw this.denied(`Paid tool '${toolName}' requires a positive tool_policy.spend_caps.session_karma value.`);
+    }
+
+    if (this.getToolCap(toolName) <= 0) {
+      throw this.denied(
+        `Paid tool '${toolName}' requires a positive tool_policy.spend_caps.default_tool_karma or per-tool cap.`
+      );
+    }
+  }
+
+  private assertBudgetAvailable(toolName: string, pendingKarma: number): void {
+    const remaining = this.getRemainingBudget(toolName);
+
+    if (remaining.session <= 0 || pendingKarma > remaining.session) {
+      throw this.denied(`Paid tool '${toolName}' would exceed the per-session karma spend cap.`);
+    }
+
+    if (remaining.tool <= 0 || pendingKarma > remaining.tool) {
+      throw this.denied(`Paid tool '${toolName}' would exceed its per-tool karma spend cap.`);
+    }
+  }
+
+  private getRemainingBudget(toolName: string): RemainingBudget {
+    return {
+      session: this.config.spend_caps.session_karma - this.sessionKarmaSpent,
+      tool: this.getToolCap(toolName) - this.getToolKarmaSpent(toolName)
+    };
+  }
+
+  private getToolCap(toolName: string): number {
+    return this.config.spend_caps.per_tool_karma[toolName] ?? this.config.spend_caps.default_tool_karma;
+  }
+
+  private denied(message: string): DevaError {
+    return new DevaError({
+      code: "TOOL_POLICY_DENIED",
+      message
+    });
+  }
+}

--- a/src/tools/ai.ts
+++ b/src/tools/ai.ts
@@ -52,7 +52,7 @@ export function createAiTools(): ToolDefinition[] {
     },
     {
       name: "deva_ai_web_search",
-      description: "Run Deva web search resource. Pricing: 5₭ ($0.005) per search.",
+      description: "Run Deva web search resource. Pricing: 10₭ ($0.01) per search.",
       inputSchema: {
         type: "object",
         description: "Search payload accepted by Deva API.",

--- a/src/tools/social.ts
+++ b/src/tools/social.ts
@@ -207,7 +207,7 @@ export function createSocialTools(): ToolDefinition[] {
     },
     {
       name: "deva_social_x_search",
-      description: "Search X content via Deva resources. Pricing: 15₭ ($0.015) per search.",
+      description: "Search X content via Deva resources. Pricing: 10₭ ($0.01) per search.",
       inputSchema: {
         type: "object",
         properties: {
@@ -255,7 +255,7 @@ export function createSocialTools(): ToolDefinition[] {
     },
     {
       name: "deva_social_x_user_tweets",
-      description: "Fetch recent tweets from a specific X/Twitter user. Pricing: 15₭ ($0.015) per request.",
+      description: "Fetch recent tweets from a specific X/Twitter user. Pricing: 10₭ ($0.01) per request.",
       inputSchema: {
         type: "object",
         properties: {

--- a/test/deva-client.test.ts
+++ b/test/deva-client.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it, vi } from "vitest";
 import { DevaClient } from "../src/deva-client.js";
 import { RuntimeConfig } from "../src/config.js";
 import { DevaError } from "../src/errors.js";
+import { buildDefaultToolPolicyConfig } from "../src/tool-policy.js";
 
 function makeConfig(): RuntimeConfig {
+  const toolPolicy = buildDefaultToolPolicyConfig();
   return {
     apiBase: "https://api.deva.me",
     profile: "default",
@@ -15,8 +17,10 @@ function makeConfig(): RuntimeConfig {
       profile: "default",
       api_base: "https://api.deva.me",
       agents: { default: { api_key: "deva_test" } },
-      defaults: { timeout_ms: 50 }
-    }
+      defaults: { timeout_ms: 50 },
+      tool_policy: toolPolicy
+    },
+    toolPolicy
   };
 }
 

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { RuntimeConfig } from "../src/config.js";
 import { DevaClient } from "../src/deva-client.js";
+import { buildDefaultToolPolicyConfig } from "../src/tool-policy.js";
 import { createAgentTools } from "../src/tools/agent.js";
 import { createAiTools } from "../src/tools/ai.js";
 import { createBalanceTools } from "../src/tools/balance.js";
@@ -14,6 +15,7 @@ const runIntegration = apiKey ? describe : describe.skip;
 const apiBase = process.env.DEVA_API_BASE ?? "https://api.deva.me";
 
 function makeConfig(): RuntimeConfig {
+  const toolPolicy = buildDefaultToolPolicyConfig();
   return {
     apiBase,
     profile: "default",
@@ -25,8 +27,10 @@ function makeConfig(): RuntimeConfig {
       profile: "default",
       api_base: apiBase,
       agents: { default: { api_key: apiKey } },
-      defaults: { timeout_ms: 30_000 }
-    }
+      defaults: { timeout_ms: 30_000 },
+      tool_policy: toolPolicy
+    },
+    toolPolicy
   };
 }
 

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi } from "vitest";
+import { DevaMcpServer } from "../src/server.js";
+import { RuntimeConfig } from "../src/config.js";
+import { ToolPolicyConfig, buildDefaultToolPolicyConfig, normalizeToolPolicyConfig } from "../src/tool-policy.js";
+import { ToolContext, ToolDefinition } from "../src/tools/types.js";
+
+interface ToolCallResult {
+  isError?: boolean;
+  content: Array<{ type: "text"; text: string }>;
+}
+
+type CallToolHandler = (
+  request: { method: "tools/call"; params: { name: string; arguments?: Record<string, unknown> } },
+  extra: unknown
+) => Promise<ToolCallResult>;
+
+function makeConfig(toolPolicy: ToolPolicyConfig): RuntimeConfig {
+  return {
+    apiBase: "https://api.deva.test",
+    profile: "default",
+    apiKey: "deva_test",
+    timeoutMs: 1_000,
+    logLevel: "error",
+    configPath: "/tmp/deva-config.json",
+    configFile: {
+      profile: "default",
+      api_base: "https://api.deva.test",
+      agents: { default: { api_key: "deva_test" } },
+      defaults: { timeout_ms: 1_000 },
+      tool_policy: toolPolicy
+    },
+    toolPolicy
+  };
+}
+
+function makePaidTool(execute: ToolDefinition["execute"]): ToolDefinition {
+  return {
+    name: "deva_ai_tts",
+    description: "Controlled paid test tool.",
+    inputSchema: { type: "object", properties: {} },
+    execute
+  };
+}
+
+function makeServer(toolPolicy: ToolPolicyConfig, execute: ToolDefinition["execute"]): DevaMcpServer {
+  const server = new DevaMcpServer(makeConfig(toolPolicy));
+  (server as unknown as { tools: ToolDefinition[] }).tools = [makePaidTool(execute)];
+  return server;
+}
+
+async function callTool(server: DevaMcpServer, args: Record<string, unknown> = {}): Promise<ToolCallResult> {
+  const handler = (server as unknown as { mcpServer: { _requestHandlers: Map<string, CallToolHandler> } }).mcpServer._requestHandlers.get(
+    "tools/call"
+  );
+
+  if (!handler) {
+    throw new Error("tools/call handler was not registered");
+  }
+
+  return handler({ method: "tools/call", params: { name: "deva_ai_tts", arguments: args } }, {});
+}
+
+function resultText(result: ToolCallResult): string {
+  return result.content[0]?.text ?? "";
+}
+
+describe("DevaMcpServer tool policy enforcement", () => {
+  it("rejects disabled paid tools at the call_tool boundary", async () => {
+    const execute = vi.fn(async () => ({ karma_cost: 1 }));
+    const server = makeServer(buildDefaultToolPolicyConfig(), execute);
+
+    const result = await callTool(server);
+
+    expect(result.isError).toBe(true);
+    expect(resultText(result)).toContain("disabled by local policy");
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when a paid call succeeds without a parseable cost", async () => {
+    const execute = vi.fn(async () => ({ ok: true }));
+    const server = makeServer(
+      normalizeToolPolicyConfig({
+        enabled_tools: ["deva_ai_tts"],
+        spend_caps: { session_karma: 5, default_tool_karma: 5 }
+      }),
+      execute
+    );
+
+    const result = await callTool(server);
+    const nextResult = await callTool(server);
+
+    expect(result.isError).toBe(true);
+    expect(resultText(result)).toContain("without a parseable karma cost");
+    expect(nextResult.isError).toBe(true);
+    expect(resultText(nextResult)).toContain("per-session karma spend cap");
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed when a paid call returns an over-cap cost", async () => {
+    const execute = vi.fn(async () => ({ karma_cost: 6 }));
+    const server = makeServer(
+      normalizeToolPolicyConfig({
+        enabled_tools: ["deva_ai_tts"],
+        spend_caps: { session_karma: 5, default_tool_karma: 5 }
+      }),
+      execute
+    );
+
+    const result = await callTool(server);
+    const nextResult = await callTool(server);
+
+    expect(result.isError).toBe(true);
+    expect(resultText(result)).toContain("remaining per-session karma spend cap");
+    expect(nextResult.isError).toBe(true);
+    expect(resultText(nextResult)).toContain("per-session karma spend cap");
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it("counts pending paid reservations against concurrent call_tool requests", async () => {
+    let resolveFirst!: (payload: unknown) => void;
+    const firstPayload = new Promise<unknown>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const execute = vi.fn((_args: Record<string, unknown>, _context: ToolContext) => firstPayload);
+    const server = makeServer(
+      normalizeToolPolicyConfig({
+        enabled_tools: ["deva_ai_tts"],
+        spend_caps: { session_karma: 5, default_tool_karma: 5 }
+      }),
+      execute
+    );
+
+    const firstCall = callTool(server);
+    expect(execute).toHaveBeenCalledTimes(1);
+
+    const concurrentResult = await callTool(server);
+    expect(concurrentResult.isError).toBe(true);
+    expect(resultText(concurrentResult)).toContain("per-session karma spend cap");
+    expect(execute).toHaveBeenCalledTimes(1);
+
+    resolveFirst({ karma_cost: 1 });
+    const firstResult = await firstCall;
+
+    expect(firstResult.isError).toBeUndefined();
+    expect(JSON.parse(resultText(firstResult))).toMatchObject({ karma_cost: 1 });
+  });
+});

--- a/test/tool-policy.test.ts
+++ b/test/tool-policy.test.ts
@@ -91,6 +91,66 @@ describe("ToolPolicyEnforcer", () => {
     expect(() => policy.assertCanExecute("deva_ai_tts")).toThrow(/per-tool karma spend cap/);
   });
 
+  it("reserves pending paid spend before settlement", () => {
+    const policy = new ToolPolicyEnforcer(
+      normalizeToolPolicyConfig({
+        enabled_tools: ["deva_ai_tts"],
+        spend_caps: {
+          session_karma: 5,
+          default_tool_karma: 5
+        }
+      })
+    );
+
+    const reservation = policy.reserveSpend("deva_ai_tts");
+    expect(reservation?.reservedKarma).toBe(5);
+    expect(policy.getSessionKarmaPending()).toBe(5);
+    expect(policy.getToolKarmaPending("deva_ai_tts")).toBe(5);
+    expect(() => policy.reserveSpend("deva_ai_tts")).toThrow(/per-session karma spend cap/);
+
+    policy.settleSpend(reservation, { karma_cost: 2 });
+    expect(policy.getSessionKarmaPending()).toBe(0);
+    expect(policy.getSessionKarmaSpent()).toBe(2);
+  });
+
+  it("fails closed when a paid response omits parseable cost", () => {
+    const policy = new ToolPolicyEnforcer(
+      normalizeToolPolicyConfig({
+        enabled_tools: ["deva_ai_tts"],
+        spend_caps: {
+          session_karma: 5,
+          default_tool_karma: 5
+        }
+      })
+    );
+
+    const reservation = policy.reserveSpend("deva_ai_tts");
+
+    expect(() => policy.settleSpend(reservation, { ok: true })).toThrow(/without a parseable karma cost/);
+    expect(policy.getSessionKarmaPending()).toBe(0);
+    expect(policy.getSessionKarmaSpent()).toBe(5);
+    expect(() => policy.assertCanExecute("deva_ai_tts")).toThrow(/per-session karma spend cap/);
+  });
+
+  it("fails closed and records over-cap successful paid responses", () => {
+    const policy = new ToolPolicyEnforcer(
+      normalizeToolPolicyConfig({
+        enabled_tools: ["deva_ai_tts"],
+        spend_caps: {
+          session_karma: 5,
+          default_tool_karma: 5
+        }
+      })
+    );
+
+    const reservation = policy.reserveSpend("deva_ai_tts");
+
+    expect(() => policy.settleSpend(reservation, { karma_cost: 6 })).toThrow(/remaining per-session karma spend cap/);
+    expect(policy.getSessionKarmaPending()).toBe(0);
+    expect(policy.getSessionKarmaSpent()).toBe(6);
+    expect(() => policy.assertCanExecute("deva_ai_tts")).toThrow(/per-session karma spend cap/);
+  });
+
   it("blocks x402 payment challenges that exceed remaining caps", () => {
     const policy = new ToolPolicyEnforcer(
       normalizeToolPolicyConfig({

--- a/test/tool-policy.test.ts
+++ b/test/tool-policy.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import { DevaError } from "../src/errors.js";
+import {
+  ToolPolicyEnforcer,
+  assertKnownToolPolicies,
+  buildDefaultToolPolicyConfig,
+  normalizeToolPolicyConfig
+} from "../src/tool-policy.js";
+import { createAgentTools } from "../src/tools/agent.js";
+import { createAiTools } from "../src/tools/ai.js";
+import { createBalanceTools } from "../src/tools/balance.js";
+import { createCapabilityTools } from "../src/tools/capabilities.js";
+import { createCommsTools } from "../src/tools/comms.js";
+import { createCronTools } from "../src/tools/cron.js";
+import { createGovernanceTools } from "../src/tools/governance.js";
+import { createMarketplaceTools } from "../src/tools/marketplace.js";
+import { createMessagingTools } from "../src/tools/messaging.js";
+import { createServerTools } from "../src/tools/servers.js";
+import { createSocialTools } from "../src/tools/social.js";
+import { createStorageTools } from "../src/tools/storage.js";
+import { createWebhookTools } from "../src/tools/webhooks.js";
+import { createWalletTools } from "../src/tools/wallet.js";
+
+function createAllTools() {
+  return [
+    ...createAgentTools(),
+    ...createSocialTools(),
+    ...createAiTools(),
+    ...createStorageTools(),
+    ...createBalanceTools(),
+    ...createMessagingTools(),
+    ...createCommsTools(),
+    ...createWalletTools(),
+    ...createGovernanceTools(),
+    ...createWebhookTools(),
+    ...createCapabilityTools(),
+    ...createCronTools(),
+    ...createMarketplaceTools(),
+    ...createServerTools()
+  ];
+}
+
+describe("ToolPolicyEnforcer", () => {
+  it("has metadata for every registered tool", () => {
+    expect(() => assertKnownToolPolicies(createAllTools())).not.toThrow();
+  });
+
+  it("allows free read tools and hides paid or state-changing tools by default", () => {
+    const policy = new ToolPolicyEnforcer(buildDefaultToolPolicyConfig());
+
+    expect(policy.canList("deva_balance_get")).toBe(true);
+    expect(policy.canList("deva_social_feed_get")).toBe(true);
+    expect(policy.canList("deva_ai_tts")).toBe(false);
+    expect(policy.canList("deva_storage_file_delete")).toBe(false);
+
+    expect(() => policy.assertCanExecute("deva_balance_get")).not.toThrow();
+    expect(() => policy.assertCanExecute("deva_ai_tts")).toThrow(/disabled by local policy/);
+    expect(() => policy.assertCanExecute("deva_storage_file_delete")).toThrow(/disabled by local policy/);
+  });
+
+  it("requires positive caps before executing enabled paid tools", () => {
+    const policy = new ToolPolicyEnforcer(
+      normalizeToolPolicyConfig({
+        enabled_tools: ["deva_ai_tts"]
+      })
+    );
+
+    expect(policy.canList("deva_ai_tts")).toBe(true);
+    expect(() => policy.assertCanExecute("deva_ai_tts")).toThrow(/session_karma/);
+  });
+
+  it("tracks returned karma costs against session and per-tool caps", () => {
+    const policy = new ToolPolicyEnforcer(
+      normalizeToolPolicyConfig({
+        enabled_tools: ["deva_ai_tts"],
+        spend_caps: {
+          session_karma: 5,
+          default_tool_karma: 3
+        }
+      })
+    );
+
+    expect(() => policy.assertCanExecute("deva_ai_tts")).not.toThrow();
+    policy.recordSpend("deva_ai_tts", { karma_cost: 2 });
+    expect(policy.getSessionKarmaSpent()).toBe(2);
+    expect(policy.getToolKarmaSpent("deva_ai_tts")).toBe(2);
+
+    expect(() => policy.assertCanExecute("deva_ai_tts")).not.toThrow();
+    policy.recordSpend("deva_ai_tts", { data: { karma_cost: 1 } });
+
+    expect(() => policy.assertCanExecute("deva_ai_tts")).toThrow(/per-tool karma spend cap/);
+  });
+
+  it("blocks x402 payment challenges that exceed remaining caps", () => {
+    const policy = new ToolPolicyEnforcer(
+      normalizeToolPolicyConfig({
+        enabled_tools: ["deva_ai_tts"],
+        spend_caps: {
+          session_karma: 5,
+          default_tool_karma: 5
+        }
+      })
+    );
+
+    expect(() =>
+      policy.assertPaymentChallengeWithinCaps(
+        "deva_ai_tts",
+        new DevaError({
+          status: 402,
+          code: "PAYMENT_REQUIRED",
+          message: "Payment required",
+          paymentChallenge: {
+            scheme: "x402",
+            network: "base",
+            amount: "0.002",
+            pay_to: "0xfeed"
+          }
+        })
+      )
+    ).not.toThrow();
+
+    expect(() =>
+      policy.assertPaymentChallengeWithinCaps(
+        "deva_ai_tts",
+        new DevaError({
+          status: 402,
+          code: "PAYMENT_REQUIRED",
+          message: "Payment required",
+          paymentChallenge: {
+            scheme: "x402",
+            network: "base",
+            amount: "0.01",
+            pay_to: "0xfeed"
+          }
+        })
+      )
+    ).toThrow(/per-session karma spend cap/);
+  });
+});


### PR DESCRIPTION
## Summary

- Add a local MCP tool policy that hides and rejects paid or state-changing tools unless they are explicitly enabled in local config.
- Require per-session and per-tool karma caps for enabled paid tools, including x402 challenge amount checks before returning payment challenges to clients.
- Align remaining package metadata and tracked install references on the canonical npm package name.
- Add an npm provenance publish workflow using GitHub Actions OIDC and pin GitHub Actions by commit SHA.
- Add a release runbook for the npm trusted-publisher setup.

## Validation

- `npm test`
- `npm run build`

## Notes

- `package.json` and the primary README install examples were already using the canonical npm package name on the base branch; this change aligns the remaining lockfile, MCP metadata, and tracked scaffold references.
- Ops follow-up: an npm package owner must configure the trusted publisher for `.github/workflows/publish.yml` with the `npm` environment before the first release through the new workflow.
