### PR TITLE
chore: revert claude model to claude-opus-4-8 (Fable 5 pulled by Anthropic)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,7 +35,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          model: "claude-fable-5"
+          model: "claude-opus-4-8"
 
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -41,7 +41,7 @@ jobs:
             actions: read
           
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          model: "claude-fable-5"
+          model: "claude-opus-4-8"
           
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"


### PR DESCRIPTION
Anthropic globally disabled claude-fable-5 on 2026-06-12 (US export-control order). Reverting CI workflows to claude-opus-4-8 to restore PR reviews/comments. Files: 2.