### PR TITLE
feat: deva_resource_run + deva_resource_inspect tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ First-run flow:
 | Messaging send/reply | 1₭ ($0.001) per send/reply (reads free) |
 | Gas faucet | 350₭ ($0.35) |
 
-Use `deva_cost_estimate` before execution and `deva_resources_catalog` for live catalog/pricing from the API.
+Use `deva_resources_catalog`, `deva_resource_inspect`, `deva_cost_estimate`, and `deva_resource_run` for the generic discover -> inspect -> run resource flow.
 
 ## Local Tool Policy
 
@@ -219,11 +219,13 @@ DEVA_API_KEY = "deva_xxx"
 - `deva_storage_file_delete` -> `DELETE /v1/agents/files/{path}`
 - `deva_storage_file_list` -> `GET /v1/agents/files`
 
-### Balance (3)
+### Balance And Resources (5)
 
 - `deva_balance_get` -> `GET /v1/agents/karma/balance`
 - `deva_cost_estimate` -> `POST /v1/agents/resources/estimate`
 - `deva_resources_catalog` -> `GET /v1/agents/resources/catalog`
+- `deva_resource_inspect` -> `GET /v1/agents/resources/catalog/{resource_id}`
+- `deva_resource_run` -> `POST /v1/agents/resources/{resource_id}/run`
 
 ### Messaging (7)
 

--- a/src/tool-policy.ts
+++ b/src/tool-policy.ts
@@ -77,6 +77,8 @@ const TOOL_SECURITY: Record<string, ToolSecurityMetadata> = {
   deva_balance_get: safe(),
   deva_cost_estimate: safe(),
   deva_resources_catalog: safe(),
+  deva_resource_inspect: safe(),
+  deva_resource_run: paid(),
 
   deva_messaging_send: paidDestructive(),
   deva_messaging_inbox: safe(),

--- a/src/tools/balance.ts
+++ b/src/tools/balance.ts
@@ -1,4 +1,12 @@
-import { ToolDefinition } from "./types.js";
+import { ToolDefinition, asString } from "./types.js";
+
+function asObject(value: unknown, fieldName: string): Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`Expected object for '${fieldName}'`);
+  }
+
+  return value as Record<string, unknown>;
+}
 
 export function createBalanceTools(): ToolDefinition[] {
   return [
@@ -34,6 +42,57 @@ export function createBalanceTools(): ToolDefinition[] {
       inputSchema: { type: "object", properties: {} },
       async execute(_args, context) {
         return context.client.request({ method: "GET", path: "/v1/agents/resources/catalog" });
+      }
+    },
+    {
+      name: "deva_resource_inspect",
+      description: "Inspect one resource's input schema, output description, pricing, and generic-run support (free).",
+      inputSchema: {
+        type: "object",
+        properties: {
+          resource_id: {
+            type: "string",
+            description: "Resource catalog id, for example web_search."
+          }
+        },
+        required: ["resource_id"],
+        additionalProperties: false
+      },
+      async execute(args, context) {
+        const resourceId = asString(args.resource_id, "resource_id");
+        return context.client.request({
+          method: "GET",
+          path: `/v1/agents/resources/catalog/${encodeURIComponent(resourceId)}`
+        });
+      }
+    },
+    {
+      name: "deva_resource_run",
+      description: "Run a generic-supported Deva resource by resource_id and params. Charges the resource's Gold Karma cost.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          resource_id: {
+            type: "string",
+            description: "Resource catalog id that supports generic run, for example web_search."
+          },
+          params: {
+            type: "object",
+            description: "Input payload matching the resource input_schema from deva_resource_inspect.",
+            additionalProperties: true
+          }
+        },
+        required: ["resource_id", "params"],
+        additionalProperties: false
+      },
+      async execute(args, context) {
+        const resourceId = asString(args.resource_id, "resource_id");
+        const params = asObject(args.params, "params");
+        return context.client.request({
+          method: "POST",
+          path: `/v1/agents/resources/${encodeURIComponent(resourceId)}/run`,
+          body: params
+        });
       }
     }
   ];

--- a/test/tool-policy.test.ts
+++ b/test/tool-policy.test.ts
@@ -49,12 +49,16 @@ describe("ToolPolicyEnforcer", () => {
     const policy = new ToolPolicyEnforcer(buildDefaultToolPolicyConfig());
 
     expect(policy.canList("deva_balance_get")).toBe(true);
+    expect(policy.canList("deva_resource_inspect")).toBe(true);
     expect(policy.canList("deva_social_feed_get")).toBe(true);
     expect(policy.canList("deva_ai_tts")).toBe(false);
+    expect(policy.canList("deva_resource_run")).toBe(false);
     expect(policy.canList("deva_storage_file_delete")).toBe(false);
 
     expect(() => policy.assertCanExecute("deva_balance_get")).not.toThrow();
+    expect(() => policy.assertCanExecute("deva_resource_inspect")).not.toThrow();
     expect(() => policy.assertCanExecute("deva_ai_tts")).toThrow(/disabled by local policy/);
+    expect(() => policy.assertCanExecute("deva_resource_run")).toThrow(/disabled by local policy/);
     expect(() => policy.assertCanExecute("deva_storage_file_delete")).toThrow(/disabled by local policy/);
   });
 

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -23,8 +23,8 @@ describe("tool inventory", () => {
       ...createGovernanceTools()
     ];
 
-    expect(all).toHaveLength(49);
-    expect(new Set(all.map((t) => t.name)).size).toBe(49);
+    expect(all).toHaveLength(51);
+    expect(new Set(all.map((t) => t.name)).size).toBe(51);
   });
 
   it("includes required balance and pricing tools", () => {
@@ -34,14 +34,16 @@ describe("tool inventory", () => {
     expect(names.has("deva_balance_get")).toBe(true);
     expect(names.has("deva_cost_estimate")).toBe(true);
     expect(names.has("deva_resources_catalog")).toBe(true);
+    expect(names.has("deva_resource_inspect")).toBe(true);
+    expect(names.has("deva_resource_run")).toBe(true);
   });
 
   it("maps balance tools to expected resource endpoints", async () => {
-    const calls: Array<{ method: string; path: string }> = [];
+    const calls: Array<{ method: string; path: string; body?: unknown }> = [];
     const context = {
       client: {
-        request: async (options: { method: string; path: string }) => {
-          calls.push({ method: options.method, path: options.path });
+        request: async (options: { method: string; path: string; body?: unknown }) => {
+          calls.push({ method: options.method, path: options.path, body: options.body });
           return {};
         }
       },
@@ -50,12 +52,28 @@ describe("tool inventory", () => {
 
     const tools = createBalanceTools();
     await tools.find((tool) => tool.name === "deva_balance_get")!.execute({}, context);
-    await tools.find((tool) => tool.name === "deva_cost_estimate")!.execute({}, context);
+    await tools
+      .find((tool) => tool.name === "deva_cost_estimate")!
+      .execute({ resource_id: "web_search", params: { query: "deva" } }, context);
     await tools.find((tool) => tool.name === "deva_resources_catalog")!.execute({}, context);
+    await tools.find((tool) => tool.name === "deva_resource_inspect")!.execute({ resource_id: "web_search" }, context);
+    await tools
+      .find((tool) => tool.name === "deva_resource_run")!
+      .execute({ resource_id: "web_search", params: { query: "deva", count: 1 } }, context);
 
-    expect(calls[0]).toEqual({ method: "GET", path: "/v1/agents/karma/balance" });
-    expect(calls[1]).toEqual({ method: "POST", path: "/v1/agents/resources/estimate" });
-    expect(calls[2]).toEqual({ method: "GET", path: "/v1/agents/resources/catalog" });
+    expect(calls[0]).toEqual({ method: "GET", path: "/v1/agents/karma/balance", body: undefined });
+    expect(calls[1]).toEqual({
+      method: "POST",
+      path: "/v1/agents/resources/estimate",
+      body: { resource_id: "web_search", params: { query: "deva" } }
+    });
+    expect(calls[2]).toEqual({ method: "GET", path: "/v1/agents/resources/catalog", body: undefined });
+    expect(calls[3]).toEqual({ method: "GET", path: "/v1/agents/resources/catalog/web_search", body: undefined });
+    expect(calls[4]).toEqual({
+      method: "POST",
+      path: "/v1/agents/resources/web_search/run",
+      body: { query: "deva", count: 1 }
+    });
   });
 
   it("uses updated pricing in paid tool descriptions", () => {


### PR DESCRIPTION
## Summary

References Bitplanet-L1/cross-eco-internal-docs#299.

Adds MCP tools for the merged generic resources rail:

- `deva_resource_inspect` -> `GET /v1/agents/resources/catalog/{resource_id}` as a safe/free catalog inspection tool.
- `deva_resource_run` -> `POST /v1/agents/resources/{resource_id}/run` with `{ resource_id, params }` input and paid-tool policy gating.
- Updates tool inventory docs and coverage for endpoint mapping and local policy visibility.

## Validation

- PASS `nice -n 10 npm run build`
- PASS `nice -n 10 npm test -- --minWorkers=1 --maxWorkers=2` (21 passed, 7 skipped)

Note: `nice -n 10 npm test -- --maxWorkers=2` was rejected by Vitest because its min/max worker settings conflicted; reran with explicit `--minWorkers=1 --maxWorkers=2`.
